### PR TITLE
Remove Python 2 support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,9 @@ History
 Pending Release
 ---------------
 
-* New release notes here
+.. Insert new release notes below this line
+
+* Drop Python 2 support, only Python 3.4+ is supported now.
 
 2.0.0 (2016-04-29)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,8 @@ Install from pip with:
 
     pip install pytest-restrict
 
+Python 3.4+ supported.
+
 Pytest will automatically find the plugin and use it when you run ``py.test``,
 however by default there are no restrictions. To restrict the test types,
 provide ``--restrict-types`` as a comma-separated list of import paths to

--- a/pytest_restrict.py
+++ b/pytest_restrict.py
@@ -1,11 +1,6 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-import sys
 from importlib import import_module
 
 import pytest
-import six
 
 __version__ = '2.0.0'
 
@@ -14,7 +9,7 @@ def pytest_addoption(parser):
     group = parser.getgroup('restrict', 'Restricts the test types allowed')
     group._addoption(
         '--restrict-types', dest='restrict_types',
-        type=six.text_type, default='',
+        type=str, default='',
         help="""A list of test types"""
     )
 
@@ -65,15 +60,15 @@ def import_string(dotted_path):
     """
     try:
         module_path, class_name = dotted_path.rsplit('.', 1)
-    except ValueError:
+    except ValueError as err:
         msg = "%s doesn't look like a module path" % dotted_path
-        six.reraise(ImportError, ImportError(msg), sys.exc_info()[2])
+        raise ImportError(msg) from err
 
     module = import_module(module_path)
 
     try:
         return getattr(module, class_name)
-    except AttributeError:
+    except AttributeError as err:
         msg = 'Module "%s" does not define a "%s" attribute/class' % (
             module_path, class_name)
-        six.reraise(ImportError, ImportError(msg), sys.exc_info()[2])
+        raise ImportError(msg) from err

--- a/requirements.in
+++ b/requirements.in
@@ -1,9 +1,6 @@
 docutils
 flake8
-futures<3.2.0
 isort
-modernize
 multilint
 pytest
 Pygments
-six

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,23 +6,16 @@
 #
 atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via pytest
-configparser==3.7.1       # via flake8
 docutils==0.14
-enum34==1.1.6             # via flake8
 flake8==3.6.0
-funcsigs==1.0.2           # via pytest
-futures==3.1.1
 isort==4.3.4
 mccabe==0.6.1             # via flake8
-modernize==0.6.1
 more-itertools==5.0.0     # via pytest
 multilint==2.4.0
-pathlib2==2.3.3           # via pytest
 pluggy==0.8.1             # via pytest
 py==1.7.0                 # via pytest
 pycodestyle==2.4.0        # via flake8
 pyflakes==2.0.0           # via flake8
 pygments==2.3.1
 pytest==4.1.1
-scandir==1.9.0            # via pathlib2
-six==1.12.0
+six==1.12.0               # via more-itertools, multilint, pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 max-line-length = 120
 

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,20 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-import codecs
 import re
 
 from setuptools import setup
 
 
 def get_version(filename):
-    with codecs.open(filename, 'r', 'utf-8') as fp:
+    with open(filename, 'r') as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
 
 version = get_version('pytest_restrict.py')
 
-with codecs.open('README.rst', 'r', 'utf-8') as readme_file:
+with open('README.rst', 'r') as readme_file:
     readme = readme_file.read()
 
-with codecs.open('HISTORY.rst', 'r', 'utf-8') as history_file:
+with open('HISTORY.rst', 'r') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 
@@ -34,9 +30,8 @@ setup(
     include_package_data=True,
     install_requires=[
         'pytest',
-        'six',
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=3.4',
     license="BSD",
     zip_safe=False,
     keywords='pytest, restrict, class',
@@ -49,8 +44,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -1,12 +1,4 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-import six
-
-if six.PY3:
-    pytest_plugins = ['pytester']
-else:
-    pytest_plugins = [b'pytester']
+pytest_plugins = ['pytester']
 
 
 def test_it_does_nothing_when_no_restriction_is_set(testdir):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{27,36}-codestyle,
-    py{27,36}
+    py3,
+    py3-codestyle
 
 [testenv]
 setenv =
@@ -10,11 +10,6 @@ install_command = pip install --no-deps {opts} {packages}
 deps = -rrequirements.txt
 commands = pytest -p no:restrict {posargs}
 
-[testenv:py27-codestyle]
-# setup.py check broken on travis python 2.7
-skip_install = true
-commands = multilint --skip setup.py
-
-[testenv:py36-codestyle]
+[testenv:py3-codestyle]
 skip_install = true
 commands = multilint


### PR DESCRIPTION
* Remove coding header and `__future__` imports
* Remove use of `six`
* In `setup.py`, remove use of `codecs.open`, stop requiring 'six' in `install_requires`, update `python_requires`, and update `classifiers`
* In `README.rst`, update to "Python 3.4+ supported."
* In `requirements.in`,  remove `futures` pin, `modernize`, and `six`, and recompile
* In `tox.ini`, stop testing on Python 2
* In `setup.cfg`, remove universal wheel building