### PR TITLE
Format code with Black

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@ pytest-restrict
 .. image:: https://img.shields.io/pypi/v/pytest-restrict.svg
         :target: https://pypi.python.org/pypi/pytest-restrict
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/python/black
+
 Pytest plugin to restrict the test types allowed.
 
 Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+target-version = ['py35']

--- a/pytest_restrict.py
+++ b/pytest_restrict.py
@@ -2,24 +2,26 @@ from importlib import import_module
 
 import pytest
 
-__version__ = '3.0.0'
+__version__ = "3.0.0"
 
 
 def pytest_addoption(parser):
-    group = parser.getgroup('restrict', 'Restricts the test types allowed')
+    group = parser.getgroup("restrict", "Restricts the test types allowed")
     group._addoption(
-        '--restrict-types', dest='restrict_types',
-        type=str, default='',
-        help="""A list of test types"""
+        "--restrict-types",
+        dest="restrict_types",
+        type=str,
+        default="",
+        help="""A list of test types""",
     )
 
 
 def pytest_collection_modifyitems(session, config, items):
-    restrict_types = config.getoption('restrict_types')
+    restrict_types = config.getoption("restrict_types")
     if not restrict_types:
         return
 
-    type_list = restrict_types.split(',')
+    type_list = restrict_types.split(",")
 
     check_type = create_check_type(type_list)
 
@@ -34,11 +36,11 @@ def pytest_collection_modifyitems(session, config, items):
 
 
 def create_check_type(types):
-    allow_none = ('None' in types)
-    bases = tuple(import_string(path) for path in types if path != 'None')
+    allow_none = "None" in types
+    bases = tuple(import_string(path) for path in types if path != "None")
 
     def check_type(item):
-        klass = getattr(item, 'cls', None)
+        klass = getattr(item, "cls", None)
         if klass is None:
             return allow_none
         return issubclass(klass, bases)
@@ -47,9 +49,8 @@ def create_check_type(types):
 
 
 def error_msg(item, restrict_types):
-    return '{} does not inherit from allowed pytest-restrict bases ({})'.format(
-        item.nodeid,
-        ','.join(restrict_types),
+    return "{} does not inherit from allowed pytest-restrict bases ({})".format(
+        item.nodeid, ",".join(restrict_types)
     )
 
 
@@ -59,7 +60,7 @@ def import_string(dotted_path):
     last name in the path. Raise ImportError if the import failed.
     """
     try:
-        module_path, class_name = dotted_path.rsplit('.', 1)
+        module_path, class_name = dotted_path.rsplit(".", 1)
     except ValueError as err:
         msg = "%s doesn't look like a module path" % dotted_path
         raise ImportError(msg) from err
@@ -70,5 +71,7 @@ def import_string(dotted_path):
         return getattr(module, class_name)
     except AttributeError as err:
         msg = 'Module "%s" does not define a "%s" attribute/class' % (
-            module_path, class_name)
+            module_path,
+            class_name,
+        )
         raise ImportError(msg) from err

--- a/requirements/py35.txt
+++ b/requirements/py35.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -32,6 +32,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py36.txt
+++ b/requirements/py36.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -32,6 +32,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py37.txt
+++ b/requirements/py37.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 docutils==0.14 \
     --hash=sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6 \
     --hash=sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274 \
@@ -32,6 +43,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8
@@ -107,6 +121,10 @@ six==1.12.0 \
     --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c \
     --hash=sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73 \
     # via bleach, packaging, pytest, readme-renderer
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,5 +1,7 @@
+black ; python_version == '3.7.*'
 docutils
 flake8
+flake8-bugbear
 isort
 multilint
 pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,16 @@
 [flake8]
-max-line-length = 120
+max-line-length = 80
+select = C,E,F,W,B,B950
+ignore = E203,E501,W503
 
 [isort]
-line_length = 120
-multi_line_output = 5
+include_trailing_comma = True
+force_grid_wrap = 0
+known_first_party = apig_wsgi
+line_length = 88
+multi_line_output = 3
 not_skip = __init__.py
+use_parentheses = True
 
 [metadata]
 license_file = LICENSE
@@ -12,4 +18,4 @@ license_file = LICENSE
 [tool:multilint]
 paths = pytest_restrict.py
         setup.py
-        tests
+        test_pytest_restrict.py

--- a/setup.py
+++ b/setup.py
@@ -4,50 +4,46 @@ from setuptools import setup
 
 
 def get_version(filename):
-    with open(filename, 'r') as fp:
+    with open(filename, "r") as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
 
-version = get_version('pytest_restrict.py')
+version = get_version("pytest_restrict.py")
 
-with open('README.rst', 'r') as readme_file:
+with open("README.rst", "r") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst', 'r') as history_file:
-    history = history_file.read().replace('.. :changelog:', '')
+with open("HISTORY.rst", "r") as history_file:
+    history = history_file.read().replace(".. :changelog:", "")
 
 
 setup(
-    name='pytest-restrict',
+    name="pytest-restrict",
     version=version,
-    description='Pytest plugin to restrict the test types allowed',
-    long_description=readme + '\n\n' + history,
+    description="Pytest plugin to restrict the test types allowed",
+    long_description=readme + "\n\n" + history,
     author="Adam Johnson",
-    author_email='me@adamj.eu',
-    url='https://github.com/adamchainz/pytest-restrict',
-    py_modules=['pytest_restrict'],
+    author_email="me@adamj.eu",
+    url="https://github.com/adamchainz/pytest-restrict",
+    py_modules=["pytest_restrict"],
     include_package_data=True,
-    install_requires=[
-        'pytest',
-    ],
-    python_requires='>=3.5',
+    install_requires=["pytest"],
+    python_requires=">=3.5",
     license="BSD",
     zip_safe=False,
-    keywords='pytest, restrict, class',
-    entry_points={
-        'pytest11': ['restrict = pytest_restrict'],
-    },
+    keywords="pytest, restrict, class",
+    entry_points={"pytest11": ["restrict = pytest_restrict"]},
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Framework :: Pytest',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Development Status :: 5 - Production/Stable",
+        "Framework :: Pytest",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/test_pytest_restrict.py
+++ b/test_pytest_restrict.py
@@ -1,4 +1,4 @@
-pytest_plugins = ['pytester']
+pytest_plugins = ["pytester"]
 
 
 def test_it_does_nothing_when_no_restriction_is_set(testdir):
@@ -25,7 +25,7 @@ def test_it_does_nothing_when_no_restriction_is_set(testdir):
             return 1
         """
     )
-    out = testdir.runpytest('--doctest-modules')
+    out = testdir.runpytest("--doctest-modules")
     out.assert_outcomes(passed=4, failed=0)
 
 
@@ -39,7 +39,7 @@ def test_it_allows_one_class(testdir):
                 pass
         """
     )
-    out = testdir.runpytest('--restrict-types', 'unittest.TestCase')
+    out = testdir.runpytest("--restrict-types", "unittest.TestCase")
     out.assert_outcomes(passed=1, failed=0)
 
 
@@ -51,11 +51,14 @@ def test_it_restricts_one_class(testdir):
                 pass
         """
     )
-    out = testdir.runpytest('--restrict-types', 'unittest.TestCase')
+    out = testdir.runpytest("--restrict-types", "unittest.TestCase")
     assert out.ret > 0
-    out.stderr.fnmatch_lines([
-        'ERROR: test_one.py::TestA::test_a does not inherit from allowed pytest-restrict bases (unittest.TestCase)'
-    ])
+    out.stderr.fnmatch_lines(
+        [
+            "ERROR: test_one.py::TestA::test_a does not inherit from allowed "
+            + "pytest-restrict bases (unittest.TestCase)"
+        ]
+    )
 
 
 def test_it_allows_one_function(testdir):
@@ -65,7 +68,7 @@ def test_it_allows_one_function(testdir):
             pass
         """
     )
-    out = testdir.runpytest('--restrict-types', 'None')
+    out = testdir.runpytest("--restrict-types", "None")
     out.assert_outcomes(passed=1, failed=0)
 
 
@@ -76,11 +79,14 @@ def test_it_restricts_one_function(testdir):
             pass
         """
     )
-    out = testdir.runpytest('--restrict-types', 'unittest.TestCase')
+    out = testdir.runpytest("--restrict-types", "unittest.TestCase")
     assert out.ret > 0
-    out.stderr.fnmatch_lines([
-        'ERROR: test_one.py::test_a does not inherit from allowed pytest-restrict bases (unittest.TestCase)'
-    ])
+    out.stderr.fnmatch_lines(
+        [
+            "ERROR: test_one.py::test_a does not inherit from allowed "
+            + "pytest-restrict bases (unittest.TestCase)"
+        ]
+    )
 
 
 def test_it_restricts_multiple_types_allowed(testdir):
@@ -104,9 +110,9 @@ def test_it_restricts_multiple_types_allowed(testdir):
         class BTest(B):
             def test_one(self):
                 pass
-        """
+        """,
     )
-    out = testdir.runpytest('--restrict-types', 'my_test_base.A,my_test_base.B')
+    out = testdir.runpytest("--restrict-types", "my_test_base.A,my_test_base.B")
     out.assert_outcomes(passed=2, failed=0)
 
 
@@ -127,11 +133,14 @@ def test_it_restricts_multiple_types_not_allowed(testdir):
         class MyTests(TestCase):
             def test_one(self):
                 pass
-        """
+        """,
     )
-    out = testdir.runpytest('--restrict-types', 'my_test_base.A,my_test_base.B')
+    out = testdir.runpytest("--restrict-types", "my_test_base.A,my_test_base.B")
     assert out.ret > 0
-    out.stderr.fnmatch_lines([
-        'ERROR: test_one.py::MyTests::test_one does not inherit from allowed pytest-restrict bases ' +
-        '(my_test_base.A,my_test_base.B)'
-    ])
+    out.stderr.fnmatch_lines(
+        [
+            "ERROR: test_one.py::MyTests::test_one does not inherit from "
+            + "allowed pytest-restrict bases "
+            + "(my_test_base.A,my_test_base.B)"
+        ]
+    )


### PR DESCRIPTION
* Add black and flake8-bugbear - automatically picked up by multilint
* Add pyproject.toml black configuration to target Python 3.5
* Reconfigure isort and flake8
* Drop flake8-commas and rely on Black's trailing comma insertion only
* Run black on the code
* Add README badge